### PR TITLE
ButtonPropsを変更

### DIFF
--- a/src/components/atoms/MainButton.tsx
+++ b/src/components/atoms/MainButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@chakra-ui/react";
+import { Button, ButtonProps } from "@chakra-ui/react";
 import { FC } from "react";
 
 // type Props = {
@@ -15,7 +15,7 @@ import { FC } from "react";
 //   );
 // };
 
-type Props = JSX.IntrinsicElements["button"] & { children: string } & { width: number } & { backgroundColor: string };
+type Props = ButtonProps & { children: string };
 
 const MainButton: FC<Props> = (props) => {
   const { children, ...rest } = props;

--- a/src/components/molecules/PostArea.tsx
+++ b/src/components/molecules/PostArea.tsx
@@ -55,7 +55,7 @@ const PostArea: FC = () => {
         placeholdername="投稿内容"
         onChange={onChangePost}
       />
-      <MainButton onClick={handleClick} color="white" width={100} backgroundColor="teal">
+      <MainButton onClick={handleClick} color="white" width={100} backgroundColor="teal" _hover={{ opacity: 0.7 }}>
         投稿
       </MainButton>
       <p></p>

--- a/src/components/molecules/PostArea.tsx
+++ b/src/components/molecules/PostArea.tsx
@@ -50,7 +50,7 @@ const PostArea: FC = () => {
         onChange={onChangeName}
       />
       <InputArea
-        name={name}
+        post={post}
         width={340}
         placeholdername="投稿内容"
         onChange={onChangePost}


### PR DESCRIPTION
#変更の背景. MainButtonをコンポーネント化して、呼び出し先での汎用性をあげたい。ChakraUIが提供するButtonPropsを持ちいてPropsを定義. #やったこと. ButtonPropsを利用. #課題. 実装に関しては特にありませんが、ButtonPropsの使い方を知りたく公式ドキュメントのURLを教えていただきたい（見つけられませんでした）